### PR TITLE
Add game engine for tracking mode

### DIFF
--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -14,7 +14,7 @@ class Bid < ApplicationRecord
     if predicted_tricks == actual_tricks
       10 + actual_tricks * 2
     else
-      actual_tricks 
+      actual_tricks
     end
   end
 end

--- a/app/models/game_participation.rb
+++ b/app/models/game_participation.rb
@@ -6,5 +6,4 @@ class GameParticipation < ApplicationRecord
   validates :player_id, uniqueness: { scope: :game_id }
   # can't have two players in the same position (in the same game)
   validates :position, presence: true, uniqueness: { scope: :game_id }, numericality: { greater_than_or_equal_to: 1 }
-
 end

--- a/lib/la_podrida.rb
+++ b/lib/la_podrida.rb
@@ -1,0 +1,12 @@
+module LaPodrida
+  class Error < StandardError; end
+  class InvalidPhase < Error; end
+  class InvalidBid < Error; end
+  class ForbiddenBidError < Error; end
+  class InvalidTrickCount < Error; end
+end
+
+require_relative "la_podrida/core/scoring"
+require_relative "la_podrida/core/forbidden_bid"
+require_relative "la_podrida/tracking/round"
+require_relative "la_podrida/tracking/game"

--- a/lib/la_podrida/core/forbidden_bid.rb
+++ b/lib/la_podrida/core/forbidden_bid.rb
@@ -1,0 +1,26 @@
+module LaPodrida
+  module Core
+    # In La Podrida, the last player to bid cannot bid a number that would
+    # make the total bids equal the cards dealt. This ensures someone must
+    # fail their bid.
+    module ForbiddenBid
+      module_function
+
+      def forbidden_number(cards_dealt:, bids:, player_count:)
+        return nil unless bids.size == player_count - 1
+
+        forbidden = cards_dealt - bids.values.sum
+        return nil if forbidden.negative?
+
+        forbidden
+      end
+
+      def forbidden?(cards_dealt:, bids:, player_count:, new_bid:)
+        forbidden = forbidden_number(cards_dealt:, bids:, player_count:)
+        return false if forbidden.nil?
+
+        new_bid == forbidden
+      end
+    end
+  end
+end

--- a/lib/la_podrida/core/scoring.rb
+++ b/lib/la_podrida/core/scoring.rb
@@ -1,0 +1,20 @@
+module LaPodrida
+  module Core
+    # Standard La Podrida scoring:
+    # - Match (predicted == actual): 10 + (actual * 2)
+    # - Mismatch: actual tricks only
+    module Scoring
+      module_function
+
+      def points(predicted:, actual:)
+        return nil if predicted.nil? || actual.nil?
+
+        if predicted == actual
+          10 + (actual * 2)
+        else
+          actual
+        end
+      end
+    end
+  end
+end

--- a/lib/la_podrida/tracking/game.rb
+++ b/lib/la_podrida/tracking/game.rb
@@ -1,0 +1,100 @@
+module LaPodrida
+  module Tracking
+    class Game
+      FRENCH_DECK_SIZE = 52
+      TRUMP_RESERVE = 1
+
+      attr_reader :players, :rounds
+
+      def initialize(players:, rounds: [])
+        raise ArgumentError, "Need at least 2 players" if players.size < 2
+
+        @players = players.freeze
+        @rounds = rounds
+      end
+
+      def create_round(cards_dealt:, has_trump: true)
+        validate_cards_dealt!(cards_dealt, has_trump:)
+
+        starting_position = next_starting_position
+        round = Round.new(
+          players:,
+          cards_dealt:,
+          starting_position:
+        )
+        @rounds << round
+        round
+      end
+
+      def max_cards_per_player(has_trump: true)
+        available = has_trump ? FRENCH_DECK_SIZE - TRUMP_RESERVE : FRENCH_DECK_SIZE
+        available / players.size
+      end
+
+      def current_round
+        rounds.find { |r| !r.complete? } || rounds.last
+      end
+
+      def current_round_number
+        current = current_round
+        return 1 if current.nil?
+
+        rounds.index(current) + 1
+      end
+
+      def points_for(player)
+        rounds.sum { |r| r.points_for(player) || 0 }
+      end
+
+      def scores
+        players.to_h { |p| [p, points_for(p)] }
+      end
+
+      def winner
+        return nil unless complete?
+
+        scores.max_by { |_, pts| pts }&.first
+      end
+
+      def complete?
+        rounds.any? && rounds.all?(&:complete?)
+      end
+
+      def valid?
+        complete? && rounds.all?(&:valid?)
+      end
+
+      def to_h
+        {
+          players: players,
+          rounds: rounds.map(&:to_h)
+        }
+      end
+
+      def self.from_h(hash)
+        rounds_data = hash[:rounds] || hash["rounds"] || []
+
+        new(
+          players: hash[:players] || hash["players"],
+          rounds: rounds_data.map { |r| Round.from_h(r) }
+        )
+      end
+
+      private
+
+      def next_starting_position
+        return 1 if rounds.empty?
+
+        last_position = rounds.last.starting_position
+        (last_position % players.size) + 1
+      end
+
+      def validate_cards_dealt!(cards_dealt, has_trump:)
+        max = max_cards_per_player(has_trump:)
+        return if cards_dealt.positive? && cards_dealt <= max
+
+        raise ArgumentError, "cards_dealt must be between 1 and #{max}"
+      end
+    end
+  end
+end

--- a/lib/la_podrida/tracking/game.rb
+++ b/lib/la_podrida/tracking/game.rb
@@ -47,7 +47,7 @@ module LaPodrida
       end
 
       def scores
-        players.to_h { |p| [p, points_for(p)] }
+        players.to_h { |p| [ p, points_for(p) ] }
       end
 
       def winner

--- a/lib/la_podrida/tracking/round.rb
+++ b/lib/la_podrida/tracking/round.rb
@@ -1,0 +1,203 @@
+module LaPodrida
+  module Tracking
+    class Round
+      PHASES = %i[bidding playing complete].freeze
+
+      attr_reader :players, :cards_dealt, :starting_position, :bids, :tricks_won, :phase
+
+      def initialize(players:, cards_dealt:, starting_position: 1, phase: :bidding, bids: {}, tricks_won: {})
+        raise ArgumentError, "players cannot be empty" if players.empty?
+        raise ArgumentError, "cards_dealt must be positive" if cards_dealt < 1
+
+        @players = players.freeze
+        @cards_dealt = cards_dealt
+        @starting_position = starting_position
+        @phase = phase
+        @bids = bids
+        @tricks_won = tricks_won
+      end
+
+      def players_in_order
+        rotation = (starting_position - 1) % players.size
+        players.rotate(rotation)
+      end
+
+      def current_bidder
+        return nil unless phase == :bidding
+
+        players_in_order.find { |p| !bids.key?(p) }
+      end
+
+      def last_bidder?(player)
+        bids.size == players.size - 1 && !bids.key?(player)
+      end
+
+      def forbidden_number
+        Core::ForbiddenBid.forbidden_number(
+          cards_dealt:,
+          bids:,
+          player_count: players.size
+        )
+      end
+
+      def place_bid(player, count)
+        validate_phase!(:bidding)
+        validate_player!(player)
+        validate_bid_count!(count)
+        validate_not_forbidden!(player, count)
+
+        @bids[player] = count
+        advance_to_playing if all_bids_placed?
+
+        self
+      end
+
+      def can_change_bid?(player)
+        phase == :bidding && bids.key?(player)
+      end
+
+      def change_bid(player, new_count)
+        validate_phase!(:bidding)
+        raise InvalidBid, "#{player} has not bid yet" unless bids.key?(player)
+        validate_bid_count!(new_count)
+
+        old_bid = @bids.delete(player)
+        if forbidden?(new_count)
+          @bids[player] = old_bid
+          raise ForbiddenBidError, "Cannot bid #{new_count} - it's the forbidden number"
+        end
+
+        @bids[player] = new_count
+        self
+      end
+
+      def record_tricks(player, count)
+        validate_phase!(:playing)
+        validate_player!(player)
+        validate_trick_count!(count)
+
+        @tricks_won[player] = count
+        advance_to_complete if all_tricks_recorded?
+
+        self
+      end
+
+      def change_tricks(player, new_count)
+        validate_phase!(:playing)
+        validate_player!(player)
+        validate_trick_count!(new_count)
+
+        @tricks_won[player] = new_count
+        self
+      end
+
+      def points_for(player)
+        return nil unless tricks_won.key?(player) && bids.key?(player)
+
+        Core::Scoring.points(
+          predicted: bids[player],
+          actual: tricks_won[player]
+        )
+      end
+
+      def total_bids
+        bids.values.sum
+      end
+
+      def total_tricks
+        tricks_won.values.sum
+      end
+
+      def valid?
+        phase == :complete &&
+          total_tricks == cards_dealt &&
+          total_bids != cards_dealt
+      end
+
+      def invalid?
+        phase == :complete && !valid?
+      end
+
+      def bidding? = phase == :bidding
+      def playing? = phase == :playing
+      def complete? = phase == :complete
+
+      def to_h
+        {
+          players: players,
+          cards_dealt: cards_dealt,
+          starting_position: starting_position,
+          phase: phase,
+          bids: bids.dup,
+          tricks_won: tricks_won.dup
+        }
+      end
+
+      def self.from_h(hash)
+        new(
+          players: hash[:players] || hash["players"],
+          cards_dealt: hash[:cards_dealt] || hash["cards_dealt"],
+          starting_position: hash[:starting_position] || hash["starting_position"] || 1,
+          phase: (hash[:phase] || hash["phase"])&.to_sym || :bidding,
+          bids: hash[:bids] || hash["bids"] || {},
+          tricks_won: hash[:tricks_won] || hash["tricks_won"] || {}
+        )
+      end
+
+      private
+
+      def validate_phase!(expected)
+        return if phase == expected
+
+        raise InvalidPhase, "Expected #{expected} phase, currently in #{phase}"
+      end
+
+      def validate_player!(player)
+        return if players.include?(player)
+
+        raise ArgumentError, "Unknown player: #{player}"
+      end
+
+      def validate_bid_count!(count)
+        raise InvalidBid, "Bid must be non-negative" if count.negative?
+        raise InvalidBid, "Bid cannot exceed cards dealt (#{cards_dealt})" if count > cards_dealt
+      end
+
+      def validate_trick_count!(count)
+        raise InvalidTrickCount, "Tricks must be non-negative" if count.negative?
+        raise InvalidTrickCount, "Tricks cannot exceed cards dealt (#{cards_dealt})" if count > cards_dealt
+      end
+
+      def validate_not_forbidden!(player, count)
+        return unless last_bidder?(player) && forbidden?(count)
+
+        raise ForbiddenBidError, "Cannot bid #{count} - it's the forbidden number"
+      end
+
+      def forbidden?(count)
+        Core::ForbiddenBid.forbidden?(
+          cards_dealt:,
+          bids:,
+          player_count: players.size,
+          new_bid: count
+        )
+      end
+
+      def all_bids_placed?
+        bids.size == players.size
+      end
+
+      def all_tricks_recorded?
+        tricks_won.size == players.size
+      end
+
+      def advance_to_playing
+        @phase = :playing
+      end
+
+      def advance_to_complete
+        @phase = :complete
+      end
+    end
+  end
+end

--- a/test/lib/la_podrida/core/forbidden_bid_test.rb
+++ b/test/lib/la_podrida/core/forbidden_bid_test.rb
@@ -7,14 +7,14 @@ module LaPodrida
         # 3 of 4 players haven't bid yet - no forbidden number
         assert_nil ForbiddenBid.forbidden_number(
           cards_dealt: 5,
-          bids: {"A" => 2},
+          bids: { "A" => 2 },
           player_count: 4
         )
       end
 
       test "forbidden number when last bidder" do
         # 3 players bid, 4th is last: can't bid (5 - 2 - 1 - 1) = 1
-        bids = {"A" => 2, "B" => 1, "C" => 1}
+        bids = { "A" => 2, "B" => 1, "C" => 1 }
         assert_equal 1, ForbiddenBid.forbidden_number(
           cards_dealt: 5,
           bids:,
@@ -24,7 +24,7 @@ module LaPodrida
 
       test "forbidden number can be zero" do
         # If others bid all the cards, forbidden is 0
-        bids = {"A" => 3, "B" => 2}
+        bids = { "A" => 3, "B" => 2 }
         assert_equal 0, ForbiddenBid.forbidden_number(
           cards_dealt: 5,
           bids:,
@@ -34,7 +34,7 @@ module LaPodrida
 
       test "forbidden number nil when overbid" do
         # If others overbid, no forbidden number (any bid is valid)
-        bids = {"A" => 4, "B" => 3}
+        bids = { "A" => 4, "B" => 3 }
         assert_nil ForbiddenBid.forbidden_number(
           cards_dealt: 5,
           bids:,
@@ -43,7 +43,7 @@ module LaPodrida
       end
 
       test "forbidden returns true when bid matches" do
-        bids = {"A" => 2, "B" => 1, "C" => 1}
+        bids = { "A" => 2, "B" => 1, "C" => 1 }
         assert ForbiddenBid.forbidden?(
           cards_dealt: 5,
           bids:,
@@ -53,7 +53,7 @@ module LaPodrida
       end
 
       test "forbidden returns false when bid differs" do
-        bids = {"A" => 2, "B" => 1, "C" => 1}
+        bids = { "A" => 2, "B" => 1, "C" => 1 }
         refute ForbiddenBid.forbidden?(
           cards_dealt: 5,
           bids:,
@@ -63,7 +63,7 @@ module LaPodrida
       end
 
       test "forbidden returns false when not last bidder" do
-        bids = {"A" => 2}
+        bids = { "A" => 2 }
         refute ForbiddenBid.forbidden?(
           cards_dealt: 5,
           bids:,
@@ -81,7 +81,7 @@ module LaPodrida
       end
 
       test "forbidden with two players" do
-        bids = {"A" => 3}
+        bids = { "A" => 3 }
         assert_equal 2, ForbiddenBid.forbidden_number(
           cards_dealt: 5,
           bids:,

--- a/test/lib/la_podrida/core/forbidden_bid_test.rb
+++ b/test/lib/la_podrida/core/forbidden_bid_test.rb
@@ -1,0 +1,93 @@
+require_relative "../test_helper"
+
+module LaPodrida
+  module Core
+    class ForbiddenBidTest < LaPodrida::TestCase
+      test "forbidden number when not last bidder" do
+        # 3 of 4 players haven't bid yet - no forbidden number
+        assert_nil ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids: {"A" => 2},
+          player_count: 4
+        )
+      end
+
+      test "forbidden number when last bidder" do
+        # 3 players bid, 4th is last: can't bid (5 - 2 - 1 - 1) = 1
+        bids = {"A" => 2, "B" => 1, "C" => 1}
+        assert_equal 1, ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids:,
+          player_count: 4
+        )
+      end
+
+      test "forbidden number can be zero" do
+        # If others bid all the cards, forbidden is 0
+        bids = {"A" => 3, "B" => 2}
+        assert_equal 0, ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids:,
+          player_count: 3
+        )
+      end
+
+      test "forbidden number nil when overbid" do
+        # If others overbid, no forbidden number (any bid is valid)
+        bids = {"A" => 4, "B" => 3}
+        assert_nil ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids:,
+          player_count: 3
+        )
+      end
+
+      test "forbidden returns true when bid matches" do
+        bids = {"A" => 2, "B" => 1, "C" => 1}
+        assert ForbiddenBid.forbidden?(
+          cards_dealt: 5,
+          bids:,
+          player_count: 4,
+          new_bid: 1
+        )
+      end
+
+      test "forbidden returns false when bid differs" do
+        bids = {"A" => 2, "B" => 1, "C" => 1}
+        refute ForbiddenBid.forbidden?(
+          cards_dealt: 5,
+          bids:,
+          player_count: 4,
+          new_bid: 0
+        )
+      end
+
+      test "forbidden returns false when not last bidder" do
+        bids = {"A" => 2}
+        refute ForbiddenBid.forbidden?(
+          cards_dealt: 5,
+          bids:,
+          player_count: 4,
+          new_bid: 3  # would be forbidden if last
+        )
+      end
+
+      test "forbidden with empty bids" do
+        assert_nil ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids: {},
+          player_count: 4
+        )
+      end
+
+      test "forbidden with two players" do
+        bids = {"A" => 3}
+        assert_equal 2, ForbiddenBid.forbidden_number(
+          cards_dealt: 5,
+          bids:,
+          player_count: 2
+        )
+      end
+    end
+  end
+end

--- a/test/lib/la_podrida/core/scoring_test.rb
+++ b/test/lib/la_podrida/core/scoring_test.rb
@@ -1,0 +1,35 @@
+require_relative "../test_helper"
+
+module LaPodrida
+  module Core
+    class ScoringTest < LaPodrida::TestCase
+      test "match with zero tricks" do
+        assert_equal 10, Scoring.points(predicted: 0, actual: 0)
+      end
+
+      test "match with tricks" do
+        assert_equal 12, Scoring.points(predicted: 1, actual: 1)
+        assert_equal 14, Scoring.points(predicted: 2, actual: 2)
+        assert_equal 20, Scoring.points(predicted: 5, actual: 5)
+      end
+
+      test "mismatch returns actual tricks" do
+        assert_equal 0, Scoring.points(predicted: 3, actual: 0)
+        assert_equal 2, Scoring.points(predicted: 0, actual: 2)
+        assert_equal 3, Scoring.points(predicted: 5, actual: 3)
+      end
+
+      test "nil predicted returns nil" do
+        assert_nil Scoring.points(predicted: nil, actual: 3)
+      end
+
+      test "nil actual returns nil" do
+        assert_nil Scoring.points(predicted: 3, actual: nil)
+      end
+
+      test "both nil returns nil" do
+        assert_nil Scoring.points(predicted: nil, actual: nil)
+      end
+    end
+  end
+end

--- a/test/lib/la_podrida/test_helper.rb
+++ b/test/lib/la_podrida/test_helper.rb
@@ -1,0 +1,25 @@
+require "minitest/autorun"
+require "active_support/testing/declarative"
+require_relative "../../../lib/la_podrida"
+
+module LaPodrida
+  class TestCase < Minitest::Test
+    extend ActiveSupport::Testing::Declarative
+
+    def player_names(count = 4)
+      ("A".."Z").first(count)
+    end
+
+    def setup_round(cards_dealt:, player_count: 4, starting_position: 1)
+      Tracking::Round.new(
+        players: player_names(player_count),
+        cards_dealt:,
+        starting_position:
+      )
+    end
+
+    def setup_game(player_count: 4)
+      Tracking::Game.new(players: player_names(player_count))
+    end
+  end
+end

--- a/test/lib/la_podrida/tracking/game_test.rb
+++ b/test/lib/la_podrida/tracking/game_test.rb
@@ -241,8 +241,8 @@ module LaPodrida
               "cards_dealt" => 5,
               "starting_position" => 1,
               "phase" => "complete",
-              "bids" => {"A" => 2, "B" => 1},
-              "tricks_won" => {"A" => 2, "B" => 3}
+              "bids" => { "A" => 2, "B" => 1 },
+              "tricks_won" => { "A" => 2, "B" => 3 }
             }
           ]
         }

--- a/test/lib/la_podrida/tracking/game_test.rb
+++ b/test/lib/la_podrida/tracking/game_test.rb
@@ -1,0 +1,306 @@
+require_relative "../test_helper"
+
+module LaPodrida
+  module Tracking
+    class GameTest < LaPodrida::TestCase
+      test "initialize with players" do
+        game = setup_game(player_count: 4)
+
+        assert_equal player_names(4), game.players
+        assert_empty game.rounds
+      end
+
+      test "initialize rejects single player" do
+        assert_raises(ArgumentError) do
+          Game.new(players: %w[A])
+        end
+      end
+
+      test "initialize rejects empty players" do
+        assert_raises(ArgumentError) do
+          Game.new(players: [])
+        end
+      end
+
+      test "max cards per player with trump" do
+        game = setup_game(player_count: 4)
+        # 51 cards / 4 players = 12
+        assert_equal 12, game.max_cards_per_player(has_trump: true)
+      end
+
+      test "max cards per player without trump" do
+        game = setup_game(player_count: 4)
+        # 52 cards / 4 players = 13
+        assert_equal 13, game.max_cards_per_player(has_trump: false)
+      end
+
+      test "max cards with different player counts" do
+        assert_equal 25, setup_game(player_count: 2).max_cards_per_player(has_trump: true)
+        assert_equal 17, setup_game(player_count: 3).max_cards_per_player(has_trump: true)
+        assert_equal 10, setup_game(player_count: 5).max_cards_per_player(has_trump: true)
+      end
+
+      test "create round" do
+        game = setup_game(player_count: 4)
+        round = game.create_round(cards_dealt: 5)
+
+        assert_equal 1, game.rounds.size
+        assert_equal 5, round.cards_dealt
+        assert_equal player_names(4), round.players
+      end
+
+      test "create round rejects zero cards" do
+        game = setup_game(player_count: 4)
+
+        assert_raises(ArgumentError) do
+          game.create_round(cards_dealt: 0)
+        end
+      end
+
+      test "create round rejects exceeding max" do
+        game = setup_game(player_count: 4)
+
+        assert_raises(ArgumentError) do
+          game.create_round(cards_dealt: 13) # max is 12 with trump
+        end
+      end
+
+      test "create round allows max without trump" do
+        game = setup_game(player_count: 4)
+        round = game.create_round(cards_dealt: 13, has_trump: false)
+
+        assert_equal 13, round.cards_dealt
+      end
+
+      test "starting position rotates" do
+        game = setup_game(player_count: 4)
+
+        r1 = game.create_round(cards_dealt: 5)
+        assert_equal 1, r1.starting_position
+
+        r2 = game.create_round(cards_dealt: 5)
+        assert_equal 2, r2.starting_position
+
+        r3 = game.create_round(cards_dealt: 5)
+        assert_equal 3, r3.starting_position
+
+        r4 = game.create_round(cards_dealt: 5)
+        assert_equal 4, r4.starting_position
+
+        r5 = game.create_round(cards_dealt: 5)
+        assert_equal 1, r5.starting_position # wraps
+      end
+
+      test "current round is first incomplete" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        game.create_round(cards_dealt: 5)
+
+        assert_same r1, game.current_round
+      end
+
+      test "current round advances when complete" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r2 = game.create_round(cards_dealt: 5)
+
+        r1.place_bid("A", 2)
+        r1.place_bid("B", 1)
+        r1.record_tricks("A", 2)
+        r1.record_tricks("B", 3)
+
+        assert_same r2, game.current_round
+      end
+
+      test "current round number" do
+        game = setup_game(player_count: 2)
+
+        assert_equal 1, game.current_round_number
+
+        r1 = game.create_round(cards_dealt: 5)
+        assert_equal 1, game.current_round_number
+
+        r1.place_bid("A", 2)
+        r1.place_bid("B", 1)
+        r1.record_tricks("A", 2)
+        r1.record_tricks("B", 3)
+
+        game.create_round(cards_dealt: 5)
+        assert_equal 2, game.current_round_number
+      end
+
+      test "points for player across rounds" do
+        game = setup_game(player_count: 2)
+
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1)
+        r1.record_tricks("A", 2).record_tricks("B", 3)
+        # A: 10 + 4 = 14, B: 3
+
+        r2 = game.create_round(cards_dealt: 3)
+        r2.place_bid("A", 1).place_bid("B", 0)
+        r2.record_tricks("A", 1).record_tricks("B", 2)
+        # A: 10 + 2 = 12, B: 2
+
+        assert_equal 26, game.points_for("A")
+        assert_equal 5, game.points_for("B")
+      end
+
+      test "scores returns all players" do
+        game = setup_game(player_count: 3)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1).place_bid("C", 0)
+        r1.record_tricks("A", 2).record_tricks("B", 3).record_tricks("C", 0)
+
+        scores = game.scores
+
+        assert_equal 14, scores["A"]
+        assert_equal 3, scores["B"]
+        assert_equal 10, scores["C"]
+      end
+
+      test "winner returns nil when not complete" do
+        game = setup_game(player_count: 2)
+        game.create_round(cards_dealt: 5)
+
+        assert_nil game.winner
+      end
+
+      test "winner returns highest scorer" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1)
+        r1.record_tricks("A", 2).record_tricks("B", 3)
+
+        assert_equal "A", game.winner
+      end
+
+      test "complete when all rounds complete" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1)
+        r1.record_tricks("A", 2).record_tricks("B", 3)
+
+        assert game.complete?
+      end
+
+      test "not complete when no rounds" do
+        game = setup_game(player_count: 2)
+        refute game.complete?
+      end
+
+      test "not complete with incomplete round" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2)
+
+        refute game.complete?
+      end
+
+      test "valid when all rounds valid" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1)
+        r1.record_tricks("A", 2).record_tricks("B", 3)
+
+        assert game.valid?
+      end
+
+      test "not valid with invalid round" do
+        game = setup_game(player_count: 2)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1)
+        r1.record_tricks("A", 2).record_tricks("B", 2) # sum = 4, not 5
+
+        refute game.valid?
+      end
+
+      test "to_h and from_h" do
+        game = setup_game(player_count: 3)
+        r1 = game.create_round(cards_dealt: 5)
+        r1.place_bid("A", 2).place_bid("B", 1).place_bid("C", 0)
+        r1.record_tricks("A", 2).record_tricks("B", 3).record_tricks("C", 0)
+
+        game.create_round(cards_dealt: 3)
+
+        hash = game.to_h
+        restored = Game.from_h(hash)
+
+        assert_equal game.players, restored.players
+        assert_equal game.rounds.size, restored.rounds.size
+        assert_equal game.rounds.first.bids, restored.rounds.first.bids
+        assert_equal game.scores, restored.scores
+      end
+
+      test "from_h with string keys" do
+        hash = {
+          "players" => player_names(2),
+          "rounds" => [
+            {
+              "players" => player_names(2),
+              "cards_dealt" => 5,
+              "starting_position" => 1,
+              "phase" => "complete",
+              "bids" => {"A" => 2, "B" => 1},
+              "tricks_won" => {"A" => 2, "B" => 3}
+            }
+          ]
+        }
+
+        game = Game.from_h(hash)
+
+        assert_equal player_names(2), game.players
+        assert_equal 1, game.rounds.size
+        assert game.complete?
+      end
+
+      test "full game flow" do
+        game = setup_game(player_count: 3)
+
+        # Round 1: 5 cards, A starts
+        r1 = game.create_round(cards_dealt: 5)
+        assert_equal "A", r1.current_bidder
+
+        r1.place_bid("A", 2)
+        r1.place_bid("B", 1)
+        # C is last, forbidden = 5 - 2 - 1 = 2
+        assert_equal 2, r1.forbidden_number
+        r1.place_bid("C", 1)
+
+        assert r1.playing?
+
+        r1.record_tricks("A", 2)
+        r1.record_tricks("B", 2)
+        r1.record_tricks("C", 1)
+
+        assert r1.complete?
+        assert r1.valid?
+
+        # Round 2: 3 cards, B starts
+        r2 = game.create_round(cards_dealt: 3)
+        assert_equal 2, r2.starting_position
+        assert_equal %w[B C A], r2.players_in_order
+
+        r2.place_bid("B", 1)
+        r2.place_bid("C", 0)
+        r2.place_bid("A", 1)
+
+        r2.record_tricks("B", 1)
+        r2.record_tricks("C", 1)
+        r2.record_tricks("A", 1)
+
+        assert game.complete?
+
+        # Final scores
+        # A: 14 (r1 match) + 12 (r2 match) = 26
+        # B: 2 (r1 mismatch) + 12 (r2 match) = 14
+        # C: 12 (r1 match) + 1 (r2 mismatch) = 13
+
+        assert_equal 26, game.points_for("A")
+        assert_equal 14, game.points_for("B")
+        assert_equal 13, game.points_for("C")
+        assert_equal "A", game.winner
+      end
+    end
+  end
+end

--- a/test/lib/la_podrida/tracking/round_test.rb
+++ b/test/lib/la_podrida/tracking/round_test.rb
@@ -68,7 +68,7 @@ module LaPodrida
         round = setup_round(player_count: 2, cards_dealt: 5)
         round.place_bid("A", 3)
 
-        assert_equal({"A" => 3}, round.bids)
+        assert_equal({ "A" => 3 }, round.bids)
       end
 
       test "place bid rejects unknown player" do
@@ -208,7 +208,7 @@ module LaPodrida
         round.place_bid("B", 1)
 
         round.record_tricks("A", 3)
-        assert_equal({"A" => 3}, round.tricks_won)
+        assert_equal({ "A" => 3 }, round.tricks_won)
       end
 
       test "cannot record tricks in bidding phase" do
@@ -341,7 +341,7 @@ module LaPodrida
           "cards_dealt" => 5,
           "starting_position" => 1,
           "phase" => "playing",
-          "bids" => {"A" => 2, "B" => 1},
+          "bids" => { "A" => 2, "B" => 1 },
           "tricks_won" => {}
         }
 
@@ -349,7 +349,7 @@ module LaPodrida
 
         assert_equal player_names(2), round.players
         assert_equal :playing, round.phase
-        assert_equal({"A" => 2, "B" => 1}, round.bids)
+        assert_equal({ "A" => 2, "B" => 1 }, round.bids)
       end
 
       test "place bid returns self" do

--- a/test/lib/la_podrida/tracking/round_test.rb
+++ b/test/lib/la_podrida/tracking/round_test.rb
@@ -1,0 +1,372 @@
+require_relative "../test_helper"
+
+module LaPodrida
+  module Tracking
+    class RoundTest < LaPodrida::TestCase
+      test "initialize with valid params" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+
+        assert_equal player_names(3), round.players
+        assert_equal 5, round.cards_dealt
+        assert_equal 1, round.starting_position
+        assert_equal :bidding, round.phase
+        assert_empty round.bids
+        assert_empty round.tricks_won
+      end
+
+      test "initialize with starting position" do
+        round = setup_round(player_count: 3, cards_dealt: 5, starting_position: 2)
+        assert_equal 2, round.starting_position
+      end
+
+      test "initialize rejects empty players" do
+        assert_raises(ArgumentError) do
+          Round.new(players: [], cards_dealt: 5)
+        end
+      end
+
+      test "initialize rejects zero cards" do
+        assert_raises(ArgumentError) do
+          setup_round(player_count: 2, cards_dealt: 0)
+        end
+      end
+
+      test "players in order with position 1" do
+        round = setup_round(player_count: 4, cards_dealt: 5, starting_position: 1)
+        assert_equal %w[A B C D], round.players_in_order
+      end
+
+      test "players in order with position 2" do
+        round = setup_round(player_count: 4, cards_dealt: 5, starting_position: 2)
+        assert_equal %w[B C D A], round.players_in_order
+      end
+
+      test "players in order with position 4" do
+        round = setup_round(player_count: 4, cards_dealt: 5, starting_position: 4)
+        assert_equal %w[D A B C], round.players_in_order
+      end
+
+      test "players in order wraps around" do
+        round = setup_round(player_count: 3, cards_dealt: 5, starting_position: 5)
+        # position 5 % 3 = 2, so starts at index 1 (B)
+        assert_equal %w[B C A], round.players_in_order
+      end
+
+      test "current bidder follows order" do
+        round = setup_round(player_count: 3, cards_dealt: 5, starting_position: 2)
+
+        assert_equal "B", round.current_bidder
+        round.place_bid("B", 1)
+
+        assert_equal "C", round.current_bidder
+        round.place_bid("C", 2)
+
+        assert_equal "A", round.current_bidder
+      end
+
+      test "place bid records bid" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 3)
+
+        assert_equal({"A" => 3}, round.bids)
+      end
+
+      test "place bid rejects unknown player" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert_raises(ArgumentError) do
+          round.place_bid("Unknown", 1)
+        end
+      end
+
+      test "place bid rejects negative" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert_raises(InvalidBid) do
+          round.place_bid("A", -1)
+        end
+      end
+
+      test "place bid rejects exceeding cards dealt" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert_raises(InvalidBid) do
+          round.place_bid("A", 6)
+        end
+      end
+
+      test "place bid allows max cards dealt" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 5)
+
+        assert_equal 5, round.bids["A"]
+      end
+
+      test "place bid allows zero" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 0)
+
+        assert_equal 0, round.bids["A"]
+      end
+
+      test "forbidden number nil when not last" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+
+        assert_nil round.forbidden_number
+      end
+
+      test "forbidden number computed for last bidder" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        # C is last, forbidden = 5 - 2 - 1 = 2
+        assert_equal 2, round.forbidden_number
+      end
+
+      test "last bidder cannot bid forbidden number" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_raises(ForbiddenBidError) do
+          round.place_bid("C", 2)
+        end
+      end
+
+      test "last bidder can bid other numbers" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        round.place_bid("C", 0)
+        assert_equal 0, round.bids["C"]
+      end
+
+      test "last bidder helper" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+
+        refute round.last_bidder?("A")
+        round.place_bid("A", 1)
+
+        refute round.last_bidder?("B")
+        round.place_bid("B", 1)
+
+        assert round.last_bidder?("C")
+      end
+
+      test "phase advances to playing after all bids" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert round.bidding?
+        round.place_bid("A", 2)
+        assert round.bidding?
+        round.place_bid("B", 1)
+        assert round.playing?
+      end
+
+      test "cannot bid in playing phase" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_raises(InvalidPhase) do
+          round.place_bid("A", 3)
+        end
+      end
+
+      test "can change bid before phase ends" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+
+        round.change_bid("A", 3)
+        assert_equal 3, round.bids["A"]
+      end
+
+      test "cannot change bid after bidding phase ends" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_raises(InvalidPhase) do
+          round.change_bid("A", 3)
+        end
+      end
+
+      test "cannot change unbid player" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert_raises(InvalidBid) do
+          round.change_bid("A", 2)
+        end
+      end
+
+      test "record tricks in playing phase" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        round.record_tricks("A", 3)
+        assert_equal({"A" => 3}, round.tricks_won)
+      end
+
+      test "cannot record tricks in bidding phase" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+
+        assert_raises(InvalidPhase) do
+          round.record_tricks("A", 3)
+        end
+      end
+
+      test "record tricks rejects negative" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_raises(InvalidTrickCount) do
+          round.record_tricks("A", -1)
+        end
+      end
+
+      test "record tricks rejects exceeding cards" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_raises(InvalidTrickCount) do
+          round.record_tricks("A", 6)
+        end
+      end
+
+      test "phase advances to complete after all tricks" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        round.record_tricks("A", 3)
+        assert round.playing?
+
+        round.record_tricks("B", 2)
+        assert round.complete?
+      end
+
+      test "change tricks in playing phase" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.record_tricks("A", 3)
+
+        round.change_tricks("A", 4)
+        assert_equal 4, round.tricks_won["A"]
+      end
+
+      test "points for match" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.record_tricks("A", 2)
+        round.record_tricks("B", 3)
+
+        assert_equal 14, round.points_for("A") # 10 + 2*2
+        assert_equal 3, round.points_for("B")  # mismatch
+      end
+
+      test "points nil before tricks recorded" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        assert_nil round.points_for("A")
+      end
+
+      test "valid round" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.record_tricks("A", 2)
+        round.record_tricks("B", 3)
+
+        assert round.valid?
+        assert round.complete?
+        refute round.invalid?
+      end
+
+      test "invalid when tricks dont sum to cards" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.record_tricks("A", 2)
+        round.record_tricks("B", 2) # total = 4, should be 5
+
+        refute round.valid?
+        assert round.invalid?
+      end
+
+      test "total bids and tricks" do
+        round = setup_round(player_count: 3, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.place_bid("C", 0)
+
+        assert_equal 3, round.total_bids
+
+        round.record_tricks("A", 2)
+        round.record_tricks("B", 2)
+        round.record_tricks("C", 1)
+
+        assert_equal 5, round.total_tricks
+      end
+
+      test "to_h and from_h" do
+        round = setup_round(player_count: 2, cards_dealt: 5, starting_position: 2)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+        round.record_tricks("A", 3)
+
+        hash = round.to_h
+        restored = Round.from_h(hash)
+
+        assert_equal round.players, restored.players
+        assert_equal round.cards_dealt, restored.cards_dealt
+        assert_equal round.starting_position, restored.starting_position
+        assert_equal round.phase, restored.phase
+        assert_equal round.bids, restored.bids
+        assert_equal round.tricks_won, restored.tricks_won
+      end
+
+      test "from_h with string keys" do
+        hash = {
+          "players" => player_names(2),
+          "cards_dealt" => 5,
+          "starting_position" => 1,
+          "phase" => "playing",
+          "bids" => {"A" => 2, "B" => 1},
+          "tricks_won" => {}
+        }
+
+        round = Round.from_h(hash)
+
+        assert_equal player_names(2), round.players
+        assert_equal :playing, round.phase
+        assert_equal({"A" => 2, "B" => 1}, round.bids)
+      end
+
+      test "place bid returns self" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        result = round.place_bid("A", 2)
+
+        assert_same round, result
+      end
+
+      test "record tricks returns self" do
+        round = setup_round(player_count: 2, cards_dealt: 5)
+        round.place_bid("A", 2)
+        round.place_bid("B", 1)
+
+        result = round.record_tricks("A", 3)
+        assert_same round, result
+      end
+    end
+  end
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -294,7 +294,6 @@ class GameTest < ActiveSupport::TestCase
 
     assert_equal 3, round9.starts_at
     assert_equal @charlie, round9.starting_player
-
   end
 
   # ----- TESTS FOR CURRENT ROUND NUMBER CALCULATION -----


### PR DESCRIPTION
Extracts game logic from Rails into lib/la_podrida with no framework dependencies. This enables fast isolated tests and opens the door for bot players and ML training later.

Core modules handle scoring and forbidden bid rules. Tracking::Round implements explicit phase state machine (bidding → playing → complete). Tracking::Game orchestrates rounds with rotating start positions.